### PR TITLE
Add no-build option:

### DIFF
--- a/download.go
+++ b/download.go
@@ -52,7 +52,7 @@ func unpackArchive(path string) error {
 	err := cmd.Run()
 	if err != nil {
 		os.Remove(path)
-		fmt.Printf("removing archive %s due to an error\n", path)
+		fmt.Fprintf(os.Stderr, "removing archive %s due to an error\n", path)
 		return fmt.Errorf("failed to unpack file %s: %w", path, err)
 	}
 	return nil
@@ -67,11 +67,11 @@ func downloadManateeSrc(ver Version) (string, error) {
 		return "", fmt.Errorf("failed to explore directory %s: %w", outDir, err)
 	}
 	if isDir {
-		fmt.Printf("found existing manatee directory in %s\n", outDir)
+		fmt.Fprintf(os.Stderr, "found existing manatee directory in %s\n", outDir)
 		return outDir, nil
 	}
 	outFile := fmt.Sprintf("/tmp/manatee-open-%s.tar.gz", ver.Semver())
-	fmt.Printf("\nLooking for %s\n", path.Base(outFile))
+	fmt.Fprintf(os.Stderr, "\nLooking for %s\n", path.Base(outFile))
 	if !fs.PathExists(outFile) {
 		url := fmt.Sprintf(
 			"https://corpora.fi.muni.cz/noske/src/manatee-open/manatee-open-%s.tar.gz",

--- a/env.go
+++ b/env.go
@@ -38,7 +38,7 @@ func (ev EnvironmentVars) Export() []string {
 
 func (ev EnvironmentVars) Print(linePrefix string) {
 	for k, v := range ev {
-		fmt.Printf("%s=%s\n", color.HiGreenString("%s%s", linePrefix, k), v)
+		fmt.Fprintf(os.Stderr, "%s=%s\n", color.HiGreenString("%s%s", linePrefix, k), v)
 	}
 }
 

--- a/runcmd.go
+++ b/runcmd.go
@@ -87,10 +87,10 @@ func RunCommand(cmd *exec.Cmd, opts ...RunCommandOption) error {
 	if cmdw.printIfErr {
 		out, err = cmdw.cmd.CombinedOutput()
 		if err != nil {
-			fmt.Println()
-			color.New(color.FgHiRed).Println(string(out))
-			color.New(color.FgHiYellow).Println("failed command: ")
-			fmt.Println("\t" + strings.Join(cmdw.cmd.Args, " "))
+			fmt.Fprintln(os.Stderr)
+			color.New(color.FgHiRed).Fprintln(os.Stderr, string(out))
+			color.New(color.FgHiYellow).Fprintln(os.Stderr, "failed command: ")
+			fmt.Fprintln(os.Stderr, "\t"+strings.Join(cmdw.cmd.Args, " "))
 		}
 		return err
 
@@ -117,7 +117,7 @@ func (seq *OperationSequence) WithPausedOutput(fn func()) {
 	defer seq.mtx.Unlock()
 	if seq.sp.Active() {
 		seq.sp.Stop()
-		fmt.Print("")
+		fmt.Fprint(os.Stderr, "")
 		fn()
 		seq.sp.Start()
 
@@ -129,7 +129,7 @@ func (seq *OperationSequence) WithPausedOutput(fn func()) {
 func (seq *OperationSequence) Fail(fn func()) {
 	if seq.sp.Active() {
 		seq.sp.Stop()
-		fmt.Print("")
+		fmt.Fprint(os.Stderr, "")
 	}
 	fn()
 	os.Exit(1) // deferred functions are not run !!!
@@ -140,7 +140,7 @@ func (seq *OperationSequence) RunOperation(title string, fn func(sq *OperationSe
 		panic("operation sequence already finished")
 	}
 	seq.currIdx++
-	color.Cyan("\n=== [%d] %s ===\n", seq.currIdx, title)
+	color.New(color.FgCyan).Fprintf(os.Stderr, "\n=== [%d] %s ===\n", seq.currIdx, title)
 
 	seq.sp = spinner.New(
 		spinner.CharSets[37],
@@ -150,8 +150,8 @@ func (seq *OperationSequence) RunOperation(title string, fn func(sq *OperationSe
 	seq.sp.Start()
 	fn(seq)
 	seq.sp.Stop()
-	fmt.Println("\U00002705 done")
-	fmt.Print("")
+	fmt.Fprintln(os.Stderr, "\U00002705 done")
+	fmt.Fprint(os.Stderr, "")
 }
 
 func (seq *OperationSequence) Finish() {


### PR DESCRIPTION
This means all the convenience/informative output now goes through stderr and anything we need to be "exported" is printed via stdout.